### PR TITLE
Allow explicit conversion between point types

### DIFF
--- a/include/mapbox/geometry/point.hpp
+++ b/include/mapbox/geometry/point.hpp
@@ -6,12 +6,20 @@ template <typename T>
 struct point
 {
     using value_type = T;
+
     point()
         : x(), y()
     {}
+
     point(T x_, T y_)
         : x(x_), y(y_)
     {}
+
+    template <class U>
+    explicit point(point<U> const& o)
+        : x(o.x), y(o.y)
+    {}
+
     value_type x;
     value_type y;
 };

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -9,6 +9,12 @@ static void testPoint() {
     assert(int(p1.x) == 0);
     assert(int(p1.y) == 0);
 
+    point<int> intPoint;
+    point<double> doublePoint;
+
+    intPoint = point<int>(doublePoint);
+    doublePoint = point<double>(intPoint);
+
     point<uint32_t> p2(2, 3);
     point<uint32_t> p3(4, 6);
 


### PR DESCRIPTION
A typical pattern in mapbox-gl-native is to convert a `point<int16_t>` representing a vector tile coordinate to a `point<double>`, do some arithmetic on the more precise representation, and then convert back (with truncation) to `point<int16_t>` at the end.

This PR enables that pattern. I'm open to other ways of enabling this if @artemp or @springmeyer know a better way.