### PR TITLE
rename point<T>::value_type to coordinate_type

### DIFF
--- a/include/mapbox/geometry/feature.hpp
+++ b/include/mapbox/geometry/feature.hpp
@@ -25,6 +25,7 @@ struct value : value_base
 template <class T>
 struct feature
 {
+    using coordinate_type = T;
     using geometry_type = mapbox::geometry::geometry<T>; // Fully qualified to avoid GCC -fpermissive error.
     using property_map = std::unordered_map<std::string, value>;
 
@@ -35,6 +36,7 @@ struct feature
 template <class T, template <typename...> class Cont = std::vector>
 struct feature_collection : Cont<feature<T>>
 {
+    using coordinate_type = T;
     using feature_type = feature<T>;
     using container_type = Cont<feature_type>;
     using container_type::container_type;

--- a/include/mapbox/geometry/geometry.hpp
+++ b/include/mapbox/geometry/geometry.hpp
@@ -29,7 +29,7 @@ using geometry_base = mapbox::util::variant<point<T>,
 template <typename T>
 struct geometry : geometry_base<T>
 {
-    using value_type = T;
+    using coordinate_type = T;
     using geometry_base<T>::geometry_base;
 
     /*
@@ -42,6 +42,7 @@ struct geometry : geometry_base<T>
 template <typename T, template <typename...> class Cont>
 struct geometry_collection : Cont<geometry<T>>
 {
+    using coordinate_type = T;
     using geometry_type = geometry<T>;
     using container_type = Cont<geometry_type>;
     using container_type::container_type;

--- a/include/mapbox/geometry/line_string.hpp
+++ b/include/mapbox/geometry/line_string.hpp
@@ -10,6 +10,7 @@ namespace mapbox { namespace geometry {
 template <typename T, template <typename...> class Cont = std::vector>
 struct line_string : Cont<point<T> >
 {
+    using coordinate_type = T;
     using point_type = point<T>;
     using container_type = Cont<point_type>;
     using container_type::container_type;

--- a/include/mapbox/geometry/multi_line_string.hpp
+++ b/include/mapbox/geometry/multi_line_string.hpp
@@ -10,6 +10,7 @@ namespace mapbox { namespace geometry {
 template <typename T, template <typename...> class Cont = std::vector>
 struct multi_line_string : Cont<line_string<T>>
 {
+    using coordinate_type = T;
     using line_string_type = line_string<T>;
     using container_type = Cont<line_string_type>;
     using container_type::container_type;

--- a/include/mapbox/geometry/multi_point.hpp
+++ b/include/mapbox/geometry/multi_point.hpp
@@ -10,6 +10,7 @@ namespace mapbox { namespace geometry {
 template <typename T, template <typename...> class Cont = std::vector>
 struct multi_point : Cont<point<T>>
 {
+    using coordinate_type = T;
     using point_type = point<T>;
     using container_type = Cont<point_type>;
     using container_type::container_type;

--- a/include/mapbox/geometry/multi_polygon.hpp
+++ b/include/mapbox/geometry/multi_polygon.hpp
@@ -10,6 +10,7 @@ namespace mapbox { namespace geometry {
 template <typename T, template <typename...> class Cont = std::vector>
 struct multi_polygon : Cont<polygon<T>>
 {
+    using coordinate_type = T;
     using polygon_type = polygon<T>;
     using container_type = Cont<polygon_type>;
     using container_type::container_type;

--- a/include/mapbox/geometry/point.hpp
+++ b/include/mapbox/geometry/point.hpp
@@ -5,15 +5,15 @@ namespace mapbox { namespace geometry {
 template <typename T>
 struct point
 {
-    using value_type = T;
+    using coordinate_type = T;
     point()
         : x(), y()
     {}
     point(T x_, T y_)
         : x(x_), y(y_)
     {}
-    value_type x;
-    value_type y;
+    T x;
+    T y;
 };
 
 template <typename T>

--- a/include/mapbox/geometry/polygon.hpp
+++ b/include/mapbox/geometry/polygon.hpp
@@ -11,12 +11,14 @@ namespace mapbox { namespace geometry {
 template <typename T>
 struct linear_ring : line_string<T>
 {
+    using coordinate_type = T;
     using line_string<T>::line_string;
 };
 
 template <typename T, template <typename...> class Cont = std::vector>
 struct polygon
 {
+    using coordinate_type = T;
     using linear_ring_type = linear_ring<T>;
     using linear_rings_container = Cont<linear_ring_type>;
 


### PR DESCRIPTION
It would be useful if all geometry types had a member type identifying the `T` template parameter. `point` currently uses `value_type` for this, but that name is already taken for the types that inherit from `vector` such as `line_string` and `multi_*`. Let's use `coordinate_type` instead.