### PR TITLE
Introduce mapbox::geometry::coordinate type

### DIFF
--- a/include/mapbox/geometry/coordinate.hpp
+++ b/include/mapbox/geometry/coordinate.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <mapbox/geometry/point.hpp>
+
+#include <type_traits>
+
+namespace mapbox {
+namespace geometry {
+
+template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
+struct coordinate : public point<T> {
+    constexpr coordinate(T lat = T(), T lon = T()) : point<T>(lon, lat) {}
+    T& latitude = point<T>::y;
+    T& longitude = point<T>::x;
+};
+
+} // namespace geometry
+} // namespace mapbox

--- a/include/mapbox/geometry/geometry.hpp
+++ b/include/mapbox/geometry/geometry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mapbox/geometry/point.hpp>
+#include <mapbox/geometry/coordinate.hpp>
 #include <mapbox/geometry/line_string.hpp>
 #include <mapbox/geometry/polygon.hpp>
 #include <mapbox/geometry/multi_point.hpp>

--- a/include/mapbox/geometry/point.hpp
+++ b/include/mapbox/geometry/point.hpp
@@ -1,18 +1,15 @@
 #pragma once
 
+#include <type_traits>
+
 namespace mapbox {
 namespace geometry {
 
-template <typename T>
+template <typename T, typename = std::enable_if_t<std::is_arithmetic<T>::value>>
 struct point
 {
     using coordinate_type = T;
-    point()
-        : x(), y()
-    {}
-    point(T x_, T y_)
-        : x(x_), y(y_)
-    {}
+    constexpr point(T x_ = T(), T y_ = T()) : x(x_), y(y_) {}
     T x;
     T y;
 };

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -31,6 +31,18 @@ static void testPoint() {
     { point<uint32_t> p(4, 6); assert((p /= 2u) == point<uint32_t>(2, 3)); }
 }
 
+static void testCoordinate() {
+    coordinate<double> c1;
+    assert(int(c1.latitude) == 0);
+    assert(int(c1.longitude) == 0);
+
+    coordinate<uint32_t> c2(2, 3);
+    coordinate<uint32_t> c3(4, 6);
+
+    assert((c2 + c3) == coordinate<uint32_t>(6, 9));
+    assert((c2 + c3) == point<uint32_t>(9, 6));
+}
+
 static void testMultiPoint() {
     multi_point<double> mp1;
     assert(mp1.size() == 0);
@@ -231,6 +243,7 @@ static void testEnvelope() {
 
 int main() {
     testPoint();
+    testCoordinate();
     testMultiPoint();
     testLineString();
     testMultiLineString();


### PR DESCRIPTION
Changes on this PR:
- Make `mapbox::geometry::point` ctor `constexpr`
- Use [SFINAE](http://en.cppreference.com/w/cpp/language/sfinae) to check for arithmetic types in `mapbox::geometry::point`
- Added `mapbox::geometry::coordinate` type, which inherits from `mapbox::geometry::point` and contains aliased `latitude` and `longitude` members to point's `y` and `x` members, respectively
- Apply [llvm-namespace-comment](http://clang.llvm.org/extra/clang-tidy/checks/llvm-namespace-comment.html) in all headers
- Use clang 3.8.0 from mason on Travis Linux Clang bot

:eyes: @mourner @artemp @jfirebaugh @springmeyer