### PR TITLE
Switch null_ptr_t type in value to null_value_t

### DIFF
--- a/include/mapbox/geometry/feature.hpp
+++ b/include/mapbox/geometry/feature.hpp
@@ -15,12 +15,23 @@ namespace geometry {
 
 struct value;
 
+struct null_value_t
+{
+    constexpr null_value_t() {}
+    constexpr null_value_t(std::nullptr_t) {}
+};
+
+inline bool operator==(const null_value_t&, const null_value_t&) { return true; }
+inline bool operator!=(const null_value_t&, const null_value_t&) { return false; }
+
+constexpr null_value_t null_value = null_value_t();
+
 // Multiple numeric types (uint64_t, int64_t, double) are present in order to support
 // the widest possible range of JSON numbers, which do not have a maximum range.
 // Implementations that produce `value`s should use that order for type preference,
 // using uint64_t for positive integers, int64_t for negative integers, and double
 // for non-integers and integers outside the range of 64 bits.
-using value_base = mapbox::util::variant<std::nullptr_t, bool, uint64_t, int64_t, double, std::string,
+using value_base = mapbox::util::variant<null_value_t, bool, uint64_t, int64_t, double, std::string,
                                          mapbox::util::recursive_wrapper<std::vector<value>>,
                                          mapbox::util::recursive_wrapper<std::unordered_map<std::string, value>>>;
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -140,7 +140,7 @@ static void testFeature() {
     p["double"] = 2.5;
     p["uint"] = uint64_t(10);
     p["int"] = int64_t(-10);
-    p["null"] = nullptr;
+    p["null"] = null_value;
 
     assert(p["bool"].is<bool>());
     assert(p["bool"] == true);
@@ -152,7 +152,12 @@ static void testFeature() {
     assert(p["uint"] == uint64_t(10));
     assert(p["int"].is<int64_t>());
     assert(p["int"] == int64_t(-10));
-    assert(p["null"].is<std::nullptr_t>());
+    assert(p["null"].is<null_value_t>());
+    assert(p["null"] == null_value);
+
+    p["null"] = nullptr;
+    assert(p["null"].is<null_value_t>());
+    assert(p["null"] == null_value);
     assert(p["null"] == nullptr);
 
     assert(p == p);


### PR DESCRIPTION
This eliminates potential implicit conversions from nullptr to std::string in a visitor context. Assignment from and comparison to nullptr is still supported.

Fixes #33.