### PR TITLE
constexpr all operators

### DIFF
--- a/include/mapbox/geometry/box.hpp
+++ b/include/mapbox/geometry/box.hpp
@@ -10,7 +10,7 @@ struct box
 {
     using point_type = point<T>;
 
-    box(point_type const& min_, point_type const& max_)
+    constexpr box(point_type const& min_, point_type const& max_)
         : min(min_), max(max_)
     {}
 
@@ -19,13 +19,13 @@ struct box
 };
 
 template <typename T>
-bool operator==(box<T> const& lhs, box<T> const& rhs)
+constexpr bool operator==(box<T> const& lhs, box<T> const& rhs)
 {
     return lhs.min == rhs.min && lhs.max == rhs.max;
 }
 
 template <typename T>
-bool operator!=(box<T> const& lhs, box<T> const& rhs)
+constexpr bool operator!=(box<T> const& lhs, box<T> const& rhs)
 {
     return lhs.min != rhs.min || lhs.max != rhs.max;
 }

--- a/include/mapbox/geometry/feature.hpp
+++ b/include/mapbox/geometry/feature.hpp
@@ -21,8 +21,8 @@ struct null_value_t
     constexpr null_value_t(std::nullptr_t) {}
 };
 
-inline bool operator==(const null_value_t&, const null_value_t&) { return true; }
-inline bool operator!=(const null_value_t&, const null_value_t&) { return false; }
+constexpr bool operator==(const null_value_t&, const null_value_t&) { return true; }
+constexpr bool operator!=(const null_value_t&, const null_value_t&) { return false; }
 
 constexpr null_value_t null_value = null_value_t();
 
@@ -57,13 +57,13 @@ struct feature
 };
 
 template <class T>
-bool operator==(feature<T> const& lhs, feature<T> const& rhs)
+constexpr bool operator==(feature<T> const& lhs, feature<T> const& rhs)
 {
     return lhs.id == rhs.id && lhs.geometry == rhs.geometry && lhs.properties == rhs.properties;
 }
 
 template <class T>
-bool operator!=(feature<T> const& lhs, feature<T> const& rhs)
+constexpr bool operator!=(feature<T> const& lhs, feature<T> const& rhs)
 {
     return !(lhs == rhs);
 }

--- a/include/mapbox/geometry/point.hpp
+++ b/include/mapbox/geometry/point.hpp
@@ -20,15 +20,15 @@ struct point
 };
 
 template <typename T>
-bool operator==(point<T> const& lhs, point<T> const& rhs)
+constexpr bool operator==(point<T> const& lhs, point<T> const& rhs)
 {
     return lhs.x == rhs.x && lhs.y == rhs.y;
 }
 
 template <typename T>
-bool operator!=(point<T> const& lhs, point<T> const& rhs)
+constexpr bool operator!=(point<T> const& lhs, point<T> const& rhs)
 {
-    return lhs.x != rhs.x || lhs.y != rhs.y;
+    return !(lhs == rhs);
 }
 
 } // namespace geometry

--- a/include/mapbox/geometry/point_arithmetic.hpp
+++ b/include/mapbox/geometry/point_arithmetic.hpp
@@ -4,55 +4,55 @@ namespace mapbox {
 namespace geometry {
 
 template <typename T>
-point<T> operator+(point<T> const& lhs, point<T> const& rhs)
+constexpr point<T> operator+(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x + rhs.x, lhs.y + rhs.y);
 }
 
 template <typename T>
-point<T> operator+(point<T> const& lhs, T const& rhs)
+constexpr point<T> operator+(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x + rhs, lhs.y + rhs);
 }
 
 template <typename T>
-point<T> operator-(point<T> const& lhs, point<T> const& rhs)
+constexpr point<T> operator-(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x - rhs.x, lhs.y - rhs.y);
 }
 
 template <typename T>
-point<T> operator-(point<T> const& lhs, T const& rhs)
+constexpr point<T> operator-(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x - rhs, lhs.y - rhs);
 }
 
 template <typename T>
-point<T> operator*(point<T> const& lhs, point<T> const& rhs)
+constexpr point<T> operator*(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x * rhs.x, lhs.y * rhs.y);
 }
 
 template <typename T>
-point<T> operator*(point<T> const& lhs, T const& rhs)
+constexpr point<T> operator*(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x * rhs, lhs.y * rhs);
 }
 
 template <typename T>
-point<T> operator/(point<T> const& lhs, point<T> const& rhs)
+constexpr point<T> operator/(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x / rhs.x, lhs.y / rhs.y);
 }
 
 template <typename T>
-point<T> operator/(point<T> const& lhs, T const& rhs)
+constexpr point<T> operator/(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x / rhs, lhs.y / rhs);
 }
 
 template <typename T>
-point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
+constexpr point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x += rhs.x;
     lhs.y += rhs.y;
@@ -60,7 +60,7 @@ point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-point<T>& operator+=(point<T>& lhs, T const& rhs)
+constexpr point<T>& operator+=(point<T>& lhs, T const& rhs)
 {
     lhs.x += rhs;
     lhs.y += rhs;
@@ -68,7 +68,7 @@ point<T>& operator+=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
+constexpr point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x -= rhs.x;
     lhs.y -= rhs.y;
@@ -76,7 +76,7 @@ point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-point<T>& operator-=(point<T>& lhs, T const& rhs)
+constexpr point<T>& operator-=(point<T>& lhs, T const& rhs)
 {
     lhs.x -= rhs;
     lhs.y -= rhs;
@@ -84,7 +84,7 @@ point<T>& operator-=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
+constexpr point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x *= rhs.x;
     lhs.y *= rhs.y;
@@ -92,7 +92,7 @@ point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-point<T>& operator*=(point<T>& lhs, T const& rhs)
+constexpr point<T>& operator*=(point<T>& lhs, T const& rhs)
 {
     lhs.x *= rhs;
     lhs.y *= rhs;
@@ -100,7 +100,7 @@ point<T>& operator*=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
+constexpr point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x /= rhs.x;
     lhs.y /= rhs.y;
@@ -108,7 +108,7 @@ point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-point<T>& operator/=(point<T>& lhs, T const& rhs)
+constexpr point<T>& operator/=(point<T>& lhs, T const& rhs)
 {
     lhs.x /= rhs;
     lhs.y /= rhs;


### PR DESCRIPTION
This is needed e.g. to make https://github.com/mapbox/mapbox-gl-native/blob/master/include/mbgl/util/geo.hpp#L171-L173 work when `mbgl::LatLng` inherits from `mapbox::geometry::point<double>`.

:eyes: @mourner @jfirebaugh 