### PR TITLE
Provide default mapbox::geometry::box ctor

### DIFF
--- a/include/mapbox/geometry/box.hpp
+++ b/include/mapbox/geometry/box.hpp
@@ -2,6 +2,8 @@
 
 #include <mapbox/geometry/point.hpp>
 
+#include <limits>
+
 namespace mapbox {
 namespace geometry {
 
@@ -9,13 +11,15 @@ template <typename T>
 struct box
 {
     using point_type = point<T>;
+    using limits = std::numeric_limits<T>;
 
+    constexpr box() = default;
     constexpr box(point_type const& min_, point_type const& max_)
         : min(min_), max(max_)
     {}
 
-    point_type min;
-    point_type max;
+    point_type min = { limits::max(), limits::max() };
+    point_type max = { limits::lowest(), limits::lowest() };
 };
 
 template <typename T>

--- a/include/mapbox/geometry/envelope.hpp
+++ b/include/mapbox/geometry/envelope.hpp
@@ -3,30 +3,20 @@
 #include <mapbox/geometry/box.hpp>
 #include <mapbox/geometry/for_each_point.hpp>
 
-#include <limits>
-
 namespace mapbox {
 namespace geometry {
 
 template <typename G, typename T = typename G::coordinate_type>
 box<T> envelope(G const& geometry)
 {
-    using limits = std::numeric_limits<T>;
-
-    T min_t = limits::has_infinity ? -limits::infinity() : limits::min();
-    T max_t = limits::has_infinity ?  limits::infinity() : limits::max();
-
-    point<T> min(max_t, max_t);
-    point<T> max(min_t, min_t);
-
+    box<T> box;
     for_each_point(geometry, [&] (point<T> const& point) {
-        if (min.x > point.x) min.x = point.x;
-        if (min.y > point.y) min.y = point.y;
-        if (max.x < point.x) max.x = point.x;
-        if (max.y < point.y) max.y = point.y;
+        if (box.min.x > point.x) box.min.x = point.x;
+        if (box.min.y > point.y) box.min.y = point.y;
+        if (box.max.x < point.x) box.max.x = point.x;
+        if (box.max.y < point.y) box.max.y = point.y;
     });
-
-    return box<T>(min, max);
+    return box;
 }
 
 } // namespace geometry


### PR DESCRIPTION
This cleans up `Envelope` code and provides a common boilerplate for custom `Box` usages e.g.  

https://github.com/mapbox/mapbox-gl-native/pull/6553/commits/a9b09854482d809bbda856af811e228b3384d07b#diff-28252c6bc5b2fa114d6d6c5361a7ab52R170

/cc @jfirebaugh @mourner
