### PR TITLE
Add testcase for g++ compile error with geometry_collection

### DIFF
--- a/include/mapbox/geometry/geometry.hpp
+++ b/include/mapbox/geometry/geometry.hpp
@@ -46,7 +46,12 @@ struct geometry_collection : Cont<geometry<T>>
     using coordinate_type = T;
     using geometry_type = geometry<T>;
     using container_type = Cont<geometry_type>;
-    using container_type::container_type;
+
+    geometry_collection() = default;
+    geometry_collection(geometry_collection const&) = default;
+    geometry_collection(geometry_collection &&) = default;
+    geometry_collection(std::initializer_list<geometry_type> && args)
+      : container_type(std::forward<std::initializer_list<geometry_type>>(args)) {};
 };
 
 } // namespace geometry

--- a/tests/collection.cpp
+++ b/tests/collection.cpp
@@ -1,0 +1,5 @@
+#include <mapbox/geometry.hpp>
+
+void test() {
+    mapbox::geometry::geometry_collection<double> gc;
+}


### PR DESCRIPTION
g++-5 and g++-6 are unable to compile `mapbox::geometry::geometry_collection`. The testcase in this PR isolates the bug that @flippmoke discovered during mapnik-vector-tile development:

```
In file included from include/mapbox/geometry/geometry.hpp:10:0,
                 from include/mapbox/geometry.hpp:9,
                 from tests/unit/collection.cpp:1:
/home/travis/build/mapbox/geometry.hpp/mason_packages/headers/variant/1.1.4/include/mapbox/variant.hpp: In instantiation of ‘const size_t mapbox::util::variant<mapbox::geometry::point<double>, mapbox::geometry::line_string<double, std::vector>, mapbox::geometry::polygon<double, std::vector>, mapbox::geometry::multi_point<double, std::vector>, mapbox::geometry::multi_line_string<double, std::vector>, mapbox::geometry::multi_polygon<double, std::vector>, mapbox::geometry::geometry_collection<double, std::vector> >::data_size’:
/home/travis/build/mapbox/geometry.hpp/mason_packages/headers/variant/1.1.4/include/mapbox/variant.hpp:566:81:   required from ‘class mapbox::util::variant<mapbox::geometry::point<double>, mapbox::geometry::line_string<double, std::vector>, mapbox::geometry::polygon<double, std::vector>, mapbox::geometry::multi_point<double, std::vector>, mapbox::geometry::multi_line_string<double, std::vector>, mapbox::geometry::multi_polygon<double, std::vector>, mapbox::geometry::geometry_collection<double, std::vector> >’
include/mapbox/geometry/geometry.hpp:31:8:   required from ‘struct mapbox::geometry::geometry<double>’
include/mapbox/geometry/geometry.hpp:49:27:   required from ‘struct mapbox::geometry::geometry_collection<double>’
tests/unit/collection.cpp:4:51:   required from here
/home/travis/build/mapbox/geometry.hpp/mason_packages/headers/variant/1.1.4/include/mapbox/variant.hpp:559:67: error: invalid application of ‘sizeof’ to incomplete type ‘mapbox::geometry::geometry_collection<double>’
     static const std::size_t data_size = detail::static_max<sizeof(Types)...>::value;
```

Full error: https://travis-ci.org/mapbox/geometry.hpp/jobs/191737918#L290

This regressed in https://github.com/mapbox/geometry.hpp/commit/f00a7aebf1358421061140fcb6adf15e500619d7.

It can be worked around by:

1) Adding template instantiation of `geometry<same_type>` before `geometry_collection<same_type>`. This happens in the `tests/test.cpp` otherwise the compile error would hit those as well.

2) Adding back the use of recursive_wrapper

/cc @artemp for help on next steps.
