### PR TITLE
Build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ matrix:
           sources: [ 'ubuntu-toolchain-r-test' ]
           packages: [ 'g++-5' ]
     - os: linux
+      env: CXX=g++-6
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'g++-6' ]
+    - os: linux
       env: CXX=clang++-3.8
       addons:
         apt:
@@ -17,8 +23,18 @@ matrix:
           packages: [ 'libstdc++-4.9-dev' ]
       before_script:
         - git submodule update --init
-        - .mason/mason install clang 3.8.0
-        - export PATH=`.mason/mason prefix clang 3.8.0`/bin:$PATH
+        - .mason/mason install clang++ 3.8.1
+        - export PATH=$(.mason/mason prefix clang++ 3.8.1)/bin:$PATH
+    - os: linux
+      env: CXX=clang++-3.9
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-4.9-dev' ]
+      before_script:
+        - git submodule update --init
+        - .mason/mason install clang++ 3.9.1
+        - export PATH=$(.mason/mason prefix clang++ 3.9.1)/bin:$PATH
     - os: osx
       osx_image: xcode7.3
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -I include -std=c++14 -Wall -Wextra -Werror
+CXXFLAGS += -I include -std=c++14 -DDEBUG -O0 -Wall -Wextra -Werror
 MASON ?= .mason/mason
 
 VARIANT = 1.1.4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS += -I include --std=c++14 -Wall -Wextra -Werror
+CXXFLAGS += -I include -std=c++14 -Wall -Wextra -Werror
 MASON ?= .mason/mason
 
 VARIANT = 1.1.4


### PR DESCRIPTION
This fixes:

  - The `-std=c++14` flag is standard, not `--std=c++14`
  - Starts testing on more compilers
  - Ensures our tests are build with assertions on (otherwise they won't be testing anything). In short, let's not depend on the compiler default and rather be explicit that we want and need assertions.