### PR TITLE
Build for g++-4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ sudo: false
 matrix:
   include:
     - os: linux
+      env: CXX=g++-4.9
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'g++-4.9' ]
+    - os: linux
       env: CXX=g++-5
       addons:
         apt:

--- a/include/mapbox/geometry/feature.hpp
+++ b/include/mapbox/geometry/feature.hpp
@@ -55,6 +55,15 @@ struct feature
     geometry_type geometry;
     property_map properties {};
     std::experimental::optional<identifier> id {};
+
+    // GCC 4.9 does not support C++14 aggregates with non-static data member
+    // initializers.
+    feature(geometry_type geometry_,
+            property_map properties_ = property_map {},
+            std::experimental::optional<identifier> id_ = std::experimental::optional<identifier> {})
+        : geometry(std::move(geometry_)),
+          properties(std::move(properties_)),
+          id(std::move(id_)) {}
 };
 
 template <class T>

--- a/include/mapbox/geometry/point_arithmetic.hpp
+++ b/include/mapbox/geometry/point_arithmetic.hpp
@@ -4,55 +4,55 @@ namespace mapbox {
 namespace geometry {
 
 template <typename T>
-constexpr point<T> operator+(point<T> const& lhs, point<T> const& rhs)
+point<T> operator+(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x + rhs.x, lhs.y + rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator+(point<T> const& lhs, T const& rhs)
+point<T> operator+(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x + rhs, lhs.y + rhs);
 }
 
 template <typename T>
-constexpr point<T> operator-(point<T> const& lhs, point<T> const& rhs)
+point<T> operator-(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x - rhs.x, lhs.y - rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator-(point<T> const& lhs, T const& rhs)
+point<T> operator-(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x - rhs, lhs.y - rhs);
 }
 
 template <typename T>
-constexpr point<T> operator*(point<T> const& lhs, point<T> const& rhs)
+point<T> operator*(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x * rhs.x, lhs.y * rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator*(point<T> const& lhs, T const& rhs)
+point<T> operator*(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x * rhs, lhs.y * rhs);
 }
 
 template <typename T>
-constexpr point<T> operator/(point<T> const& lhs, point<T> const& rhs)
+point<T> operator/(point<T> const& lhs, point<T> const& rhs)
 {
     return point<T>(lhs.x / rhs.x, lhs.y / rhs.y);
 }
 
 template <typename T>
-constexpr point<T> operator/(point<T> const& lhs, T const& rhs)
+point<T> operator/(point<T> const& lhs, T const& rhs)
 {
     return point<T>(lhs.x / rhs, lhs.y / rhs);
 }
 
 template <typename T>
-constexpr point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
+point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x += rhs.x;
     lhs.y += rhs.y;
@@ -60,7 +60,7 @@ constexpr point<T>& operator+=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator+=(point<T>& lhs, T const& rhs)
+point<T>& operator+=(point<T>& lhs, T const& rhs)
 {
     lhs.x += rhs;
     lhs.y += rhs;
@@ -68,7 +68,7 @@ constexpr point<T>& operator+=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
+point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x -= rhs.x;
     lhs.y -= rhs.y;
@@ -76,7 +76,7 @@ constexpr point<T>& operator-=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator-=(point<T>& lhs, T const& rhs)
+point<T>& operator-=(point<T>& lhs, T const& rhs)
 {
     lhs.x -= rhs;
     lhs.y -= rhs;
@@ -84,7 +84,7 @@ constexpr point<T>& operator-=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
+point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x *= rhs.x;
     lhs.y *= rhs.y;
@@ -92,7 +92,7 @@ constexpr point<T>& operator*=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator*=(point<T>& lhs, T const& rhs)
+point<T>& operator*=(point<T>& lhs, T const& rhs)
 {
     lhs.x *= rhs;
     lhs.y *= rhs;
@@ -100,7 +100,7 @@ constexpr point<T>& operator*=(point<T>& lhs, T const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
+point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
 {
     lhs.x /= rhs.x;
     lhs.y /= rhs.y;
@@ -108,7 +108,7 @@ constexpr point<T>& operator/=(point<T>& lhs, point<T> const& rhs)
 }
 
 template <typename T>
-constexpr point<T>& operator/=(point<T>& lhs, T const& rhs)
+point<T>& operator/=(point<T>& lhs, T const& rhs)
 {
     lhs.x /= rhs;
     lhs.y /= rhs;


### PR DESCRIPTION
Adds support for compiling geometry.hpp tests - thus also working as a valid use case - in GCC 4.9. Unfortunately, there are some bugs in GCC 4.9 that we have to accommodate.