### PR TITLE
Moved feature.hpp to depend on geometry.hpp and not vise versa

### DIFF
--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
-#include <experimental/optional>
 
 namespace mapbox {
 namespace feature {
@@ -44,7 +43,7 @@ struct value : value_base
 using property_map = std::unordered_map<std::string, value>;
 
 // The same considerations and requirement for numeric types apply as for `value_base`.
-using identifier = mapbox::util::variant<uint64_t, int64_t, double, std::string>;
+using identifier = mapbox::util::variant<null_value_t, uint64_t, int64_t, double, std::string>;
 
 template <class T>
 struct feature
@@ -53,8 +52,8 @@ struct feature
     using geometry_type = mapbox::geometry::geometry<T>; // Fully qualified to avoid GCC -fpermissive error.
 
     geometry_type geometry;
-    property_map properties {};
-    std::experimental::optional<identifier> id {};
+    property_map properties;
+    identifier id;
 };
 
 template <class T>

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -52,8 +52,8 @@ struct feature
     using geometry_type = mapbox::geometry::geometry<T>; // Fully qualified to avoid GCC -fpermissive error.
 
     geometry_type geometry;
-    property_map properties;
-    identifier id;
+    property_map properties {};
+    identifier id {};
 };
 
 template <class T>

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <mapbox/geometry/geometry.hpp>
+#include <mapbox/geometry.hpp>
 
 #include <mapbox/variant.hpp>
 
@@ -11,7 +11,7 @@
 #include <experimental/optional>
 
 namespace mapbox {
-namespace geometry {
+namespace feature {
 
 struct value;
 

--- a/include/mapbox/geometry.hpp
+++ b/include/mapbox/geometry.hpp
@@ -7,7 +7,6 @@
 #include <mapbox/geometry/multi_line_string.hpp>
 #include <mapbox/geometry/multi_polygon.hpp>
 #include <mapbox/geometry/geometry.hpp>
-#include <mapbox/geometry/feature.hpp>
 #include <mapbox/geometry/point_arithmetic.hpp>
 #include <mapbox/geometry/for_each_point.hpp>
 #include <mapbox/geometry/envelope.hpp>

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,8 +1,10 @@
 #include <mapbox/geometry.hpp>
+#include <mapbox/feature.hpp>
 
 #include <cassert>
 
 using namespace mapbox::geometry;
+using namespace mapbox::feature;
 
 static void testPoint() {
     point<double> p1;


### PR DESCRIPTION
`feature.hpp` is currently embedded as part of `geometry.hpp`. This is not ideal because including `geometry.hpp` shouldn't require a feature object. It seems odd as well to have it under the `mapbox::geometry` namespace. 

This change moves the `feature.hpp` to the `mapbox::feature` namespace and moves the file to be included at `#include <mapbox/feature.hpp>`

/cc @artemp 