### PR TITLE
Add "circle" geometry type

### DIFF
--- a/include/mapbox/geometry.hpp
+++ b/include/mapbox/geometry.hpp
@@ -11,3 +11,4 @@
 #include <mapbox/geometry/point_arithmetic.hpp>
 #include <mapbox/geometry/for_each_point.hpp>
 #include <mapbox/geometry/envelope.hpp>
+#include <mapbox/geometry/circle.hpp>

--- a/include/mapbox/geometry/circle.hpp
+++ b/include/mapbox/geometry/circle.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <mapbox/geometry/point.hpp>
+
+namespace mapbox {
+namespace geometry {
+
+template <typename T>
+struct circle
+{
+    using point_type = point<T>;
+
+    constexpr circle(point_type const& center_, T const& radius_)
+        : center(center_), radius(radius_)
+    {}
+
+    point_type center;
+    T radius;
+};
+
+template <typename T>
+constexpr bool operator==(circle<T> const& lhs, circle<T> const& rhs)
+{
+    return lhs.center == rhs.center && lhs.radius == rhs.radius;
+}
+
+template <typename T>
+constexpr bool operator!=(circle<T> const& lhs, circle<T> const& rhs)
+{
+    return lhs.center != rhs.center || lhs.radius != rhs.radius;
+}
+
+} // namespace geometry
+} // namespace mapbox

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -242,6 +242,26 @@ static void testEnvelope() {
     assert(envelope(geometry_collection<int>({point<int>(0, 0)})) == box<int>({0, 0}, {0, 0}));
 }
 
+static void testCircle() {
+    point<int> center1(1, 2);
+    point<int> center2(2, 1);
+    circle<int> circle1(center1, 5);
+    circle<int> circle2(center1, 6);
+    circle<int> circle3(center2, 5);
+    circle<int> circle4(center1, 5);
+
+    assert(!(circle1 == circle2));
+    assert(circle1 != circle2);
+    assert(!(circle1 == circle3));
+    assert(circle1 != circle3);
+    assert(circle1 == circle4);
+    assert(!(circle1 != circle4));
+
+    assert(circle2 != circle3);
+    assert(circle2 != circle4);
+    assert(circle3 != circle4);
+}
+
 int main() {
     testPoint();
     testMultiPoint();
@@ -256,5 +276,6 @@ int main() {
 
     testForEachPoint();
     testEnvelope();
+    testCircle();
     return 0;
 }


### PR DESCRIPTION
The work in https://github.com/mapbox/mapbox-gl-native/pull/10103 uses `mapbox/geometry.hpp` for collision geometries, and needs a circle type added.

I just read the readme of `geometry.hpp` and saw that it's intended for GeoJSON geometry types, so maybe "circle" is not actually a good fit here?

/cc @ansis @jfirebaugh 