### PR TITLE
Expose size_type from geometry containers

### DIFF
--- a/include/mapbox/geometry/feature.hpp
+++ b/include/mapbox/geometry/feature.hpp
@@ -85,6 +85,7 @@ struct feature_collection : Cont<feature<T>>
     using feature_type = feature<T>;
     using container_type = Cont<feature_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/geometry.hpp
+++ b/include/mapbox/geometry/geometry.hpp
@@ -46,6 +46,7 @@ struct geometry_collection : Cont<geometry<T>>
     using coordinate_type = T;
     using geometry_type = geometry<T>;
     using container_type = Cont<geometry_type>;
+    using size_type = typename container_type::size_type;
 
     geometry_collection() = default;
     geometry_collection(geometry_collection const&) = default;

--- a/include/mapbox/geometry/line_string.hpp
+++ b/include/mapbox/geometry/line_string.hpp
@@ -15,6 +15,7 @@ struct line_string : Cont<point<T> >
     using point_type = point<T>;
     using container_type = Cont<point_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/multi_line_string.hpp
+++ b/include/mapbox/geometry/multi_line_string.hpp
@@ -15,6 +15,7 @@ struct multi_line_string : Cont<line_string<T>>
     using line_string_type = line_string<T>;
     using container_type = Cont<line_string_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/multi_point.hpp
+++ b/include/mapbox/geometry/multi_point.hpp
@@ -15,6 +15,7 @@ struct multi_point : Cont<point<T>>
     using point_type = point<T>;
     using container_type = Cont<point_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/multi_polygon.hpp
+++ b/include/mapbox/geometry/multi_polygon.hpp
@@ -15,6 +15,7 @@ struct multi_polygon : Cont<polygon<T>>
     using polygon_type = polygon<T>;
     using container_type = Cont<polygon_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/polygon.hpp
+++ b/include/mapbox/geometry/polygon.hpp
@@ -16,6 +16,7 @@ struct linear_ring : Cont<point<T>>
     using point_type = point<T>;
     using container_type = Cont<point_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 template <typename T, template <typename...> class Cont = std::vector>
@@ -25,6 +26,7 @@ struct polygon : Cont<linear_ring<T>>
     using linear_ring_type = linear_ring<T>;
     using container_type = Cont<linear_ring_type>;
     using container_type::container_type;
+    using size_type = typename container_type::size_type;
 };
 
 } // namespace geometry


### PR DESCRIPTION
Assuming we're dealing with STL containers, `size_type` forwards the underlying container size type, to be used in e.g. for loops.