### PR TITLE
Fix geometry_collection constructor for std::initializer_list

### DIFF
--- a/include/mapbox/geometry/geometry.hpp
+++ b/include/mapbox/geometry/geometry.hpp
@@ -51,8 +51,8 @@ struct geometry_collection : Cont<geometry<T>>
     geometry_collection() = default;
     geometry_collection(geometry_collection const&) = default;
     geometry_collection(geometry_collection &&) = default;
-    geometry_collection(std::initializer_list<geometry_type> && args)
-      : container_type(std::forward<std::initializer_list<geometry_type>>(args)) {};
+    geometry_collection(std::initializer_list<geometry_type> args)
+      : container_type(args) {}
 };
 
 } // namespace geometry


### PR DESCRIPTION
The constructor should accept initializer_list by value and thus fit for both lvalues and rvalues.
`std::initializer_list<geometry_type>&&` is not a forwarding (aka universal) referenece type, no need to forward.