### PR TITLE
Fix compilation errors with libc++ on QNX 7

### DIFF
--- a/include/mapbox/geometry/feature.hpp
+++ b/include/mapbox/geometry/feature.hpp
@@ -84,8 +84,12 @@ struct feature_collection : Cont<feature<T>>
     using coordinate_type = T;
     using feature_type = feature<T>;
     using container_type = Cont<feature_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    feature_collection(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    feature_collection(std::initializer_list<feature_type> args)
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/geometry.hpp
+++ b/include/mapbox/geometry/geometry.hpp
@@ -48,11 +48,10 @@ struct geometry_collection : Cont<geometry<T>>
     using container_type = Cont<geometry_type>;
     using size_type = typename container_type::size_type;
 
-    geometry_collection() = default;
-    geometry_collection(geometry_collection const&) = default;
-    geometry_collection(geometry_collection &&) = default;
+    template <class... Args>
+    geometry_collection(Args&&... args) : container_type(std::forward<Args>(args)...) {}
     geometry_collection(std::initializer_list<geometry_type> args)
-      : container_type(args) {}
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/line_string.hpp
+++ b/include/mapbox/geometry/line_string.hpp
@@ -14,8 +14,12 @@ struct line_string : Cont<point<T> >
     using coordinate_type = T;
     using point_type = point<T>;
     using container_type = Cont<point_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    line_string(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    line_string(std::initializer_list<point_type> args)
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/multi_line_string.hpp
+++ b/include/mapbox/geometry/multi_line_string.hpp
@@ -14,8 +14,12 @@ struct multi_line_string : Cont<line_string<T>>
     using coordinate_type = T;
     using line_string_type = line_string<T>;
     using container_type = Cont<line_string_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    multi_line_string(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    multi_line_string(std::initializer_list<line_string_type> args)
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/multi_point.hpp
+++ b/include/mapbox/geometry/multi_point.hpp
@@ -14,8 +14,12 @@ struct multi_point : Cont<point<T>>
     using coordinate_type = T;
     using point_type = point<T>;
     using container_type = Cont<point_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    multi_point(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    multi_point(std::initializer_list<point_type> args)
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/multi_polygon.hpp
+++ b/include/mapbox/geometry/multi_polygon.hpp
@@ -14,8 +14,12 @@ struct multi_polygon : Cont<polygon<T>>
     using coordinate_type = T;
     using polygon_type = polygon<T>;
     using container_type = Cont<polygon_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    multi_polygon(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    multi_polygon(std::initializer_list<polygon_type> args)
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry

--- a/include/mapbox/geometry/polygon.hpp
+++ b/include/mapbox/geometry/polygon.hpp
@@ -15,8 +15,12 @@ struct linear_ring : Cont<point<T>>
     using coordinate_type = T;
     using point_type = point<T>;
     using container_type = Cont<point_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    linear_ring(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    linear_ring(std::initializer_list<point_type> args)
+        : container_type(std::move(args)) {}
 };
 
 template <typename T, template <typename...> class Cont = std::vector>
@@ -25,8 +29,12 @@ struct polygon : Cont<linear_ring<T>>
     using coordinate_type = T;
     using linear_ring_type = linear_ring<T>;
     using container_type = Cont<linear_ring_type>;
-    using container_type::container_type;
     using size_type = typename container_type::size_type;
+
+    template <class... Args>
+    polygon(Args&&... args) : container_type(std::forward<Args>(args)...) {}
+    polygon(std::initializer_list<linear_ring_type> args)
+        : container_type(std::move(args)) {}
 };
 
 } // namespace geometry


### PR DESCRIPTION
It seems that the QNX 7 compiler (i.e qcc based GCC 5.4.0 with libc++ from LLVM) has a limited c++11 feature support and causing the compilation errors with the inheriting constructors.

compilation errors on QNX 7: 
``
workspace/qt5/qtlocation/src/3rdparty/mapbox-gl-native/deps/geometry/0.9.2/include/mapbox/geometry/line_string.hpp: In instantiation of 'struct mapbox::geometry::line_string<double>':
workspace/qt5/qtlocation/src/3rdparty/mapbox-gl-native/platform/qt/src/qt_geojson.cpp:21:85:   required from here
workspace/qt5/qtlocation/src/3rdparty/mapbox-gl-native/deps/geometry/0.9.2/include/mapbox/geometry/line_string.hpp:19:27: error: 'template<class _InputIterator> mapbox::geometry::line_string<double>::line_string(_InputIterator, _InputIterator, const allocator_type&)' inherited from 'std::__1::vector<mapbox::geometry::point<double> >'
     using container_type::container_type;
                           ^
workspace/qt5/qtlocation/src/3rdparty/mapbox-gl-native/deps/geometry/0.9.2/include/mapbox/geometry/line_string.hpp:19:27: error: conflicts with version inherited from 'std::__1::vector<mapbox::geometry::point<double> >'
cc: workspace/qnx700/host/linux/x86_64/usr/lib/gcc/x86_64-pc-nto-qnx7.0.0/5.4.0/cc1plus error 1
``

This patch fixes the issues by providing the required constructors explicitly.