### PR TITLE
Recursive feature values through shared ptrs

### DIFF
--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -73,8 +73,10 @@ struct value : public value_base
 {
     using array_type = std::vector<value>;
     using array_ptr_type = std::shared_ptr<std::vector<value>>;
+    using const_array_ptr_type = std::shared_ptr<const std::vector<value>>;
     using object_type = std::unordered_map<std::string, value>;
     using object_ptr_type = std::shared_ptr<std::unordered_map<std::string, value>>;
+    using const_object_ptr_type = std::shared_ptr<const std::unordered_map<std::string, value>>;
 
     value() : value_base(null_value) {}
     value(null_value_t) : value_base(null_value) {}
@@ -125,10 +127,10 @@ struct value : public value_base
     array_ptr_type getArray() noexcept
     {
         return match(
-            [](array_ptr_type& val) -> array_ptr_type { return array_ptr_type(val); },
-            [](auto&) -> array_ptr_type { return array_ptr_type(); });
+            [](array_ptr_type& val) -> array_ptr_type { return val; },
+            [](auto&) -> array_ptr_type { return nullptr; });
     }
-    const array_ptr_type getArray() const noexcept
+    const_array_ptr_type getArray() const noexcept
     {
         return const_cast<value*>(this)->getArray();
     }
@@ -136,10 +138,10 @@ struct value : public value_base
     object_ptr_type getObject() noexcept
     {
         return match(
-            [](object_ptr_type& val) -> object_ptr_type { return object_ptr_type(val); },
-            [](auto&) -> object_ptr_type { return object_ptr_type(); });
+            [](object_ptr_type& val) -> object_ptr_type { return val; },
+            [](auto&) -> object_ptr_type { return nullptr; });
     }
-    const object_ptr_type getObject() const noexcept
+    const_object_ptr_type getObject() const noexcept
     {
         return const_cast<value*>(this)->getObject();
     }

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -18,9 +18,7 @@ struct equal_comp_shared_ptr
 {
 
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #pragma GCC diagnostic ignored "-Wfloat-equal"
-#pragma GCC diagnostic ignored "-Werror=float-equal"
     template <typename T>
     bool operator()(T const& lhs, T const& rhs) const
     {

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -17,14 +17,16 @@ namespace feature {
 struct equal_comp_shared_ptr
 {
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Werror=float-equal"
     template <typename T>
     bool operator()(T const& lhs, T const& rhs) const
     {
         return lhs == rhs;
     }
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 
     template <typename T>
     bool operator()(std::shared_ptr<T> const& lhs, std::shared_ptr<T> const& rhs) const

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -25,6 +25,8 @@ constexpr bool operator<(const null_value_t&, const null_value_t&) { return fals
 
 constexpr null_value_t null_value = null_value_t();
 
+
+
 #define DECLARE_VALUE_TYPE_ACCESOR(NAME, TYPE)        \
     TYPE* get##NAME() noexcept                        \
     {                                                 \
@@ -42,8 +44,8 @@ constexpr null_value_t null_value = null_value_t();
 // using uint64_t for positive integers, int64_t for negative integers, and double
 // for non-integers and integers outside the range of 64 bits.
 using value_base = mapbox::util::variant<null_value_t, bool, uint64_t, int64_t, double, std::string,
-                                         mapbox::util::recursive_wrapper<std::shared_ptr<std::vector<value>>>,
-                                         mapbox::util::recursive_wrapper<std::shared_ptr<std::unordered_map<std::string, value>>>>;
+                                         std::shared_ptr<std::vector<value>>,
+                                         std::shared_ptr<std::unordered_map<std::string, value>>>;
 
 struct value : public value_base
 {
@@ -78,6 +80,7 @@ struct value : public value_base
     value(array_ptr_type array) : value_base(array) {}
     value(object_type object) : value_base(std::make_shared<object_type>(std::forward<object_type>(object))) {}
     value(object_ptr_type object) : value_base(object) {}
+
 
     explicit operator bool() const { return !is<null_value_t>(); }
 

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <memory>
 #include <unordered_map>
 
 namespace mapbox {
@@ -41,13 +42,15 @@ constexpr null_value_t null_value = null_value_t();
 // using uint64_t for positive integers, int64_t for negative integers, and double
 // for non-integers and integers outside the range of 64 bits.
 using value_base = mapbox::util::variant<null_value_t, bool, uint64_t, int64_t, double, std::string,
-                                         mapbox::util::recursive_wrapper<std::vector<value>>,
-                                         mapbox::util::recursive_wrapper<std::unordered_map<std::string, value>>>;
+                                         mapbox::util::recursive_wrapper<std::shared_ptr<std::vector<value>>>,
+                                         mapbox::util::recursive_wrapper<std::shared_ptr<std::unordered_map<std::string, value>>>>;
 
 struct value : public value_base
 {
     using array_type = std::vector<value>;
+    using array_ptr_type = std::shared_ptr<std::vector<value>>;
     using object_type = std::unordered_map<std::string, value>;
+    using object_ptr_type = std::shared_ptr<std::unordered_map<std::string, value>>;
 
     value() : value_base(null_value) {}
     value(null_value_t) : value_base(null_value) {}
@@ -71,8 +74,10 @@ struct value : public value_base
     value(T t) : value_base(double(t))
     {
     }
-    value(array_type array) : value_base(std::move(array)) {}
-    value(object_type object) : value_base(std::move(object)) {}
+    value(array_type array) : value_base(std::make_shared<array_type>(std::forward<array_type>(array))) {}
+    value(array_ptr_type array) : value_base(array) {}
+    value(object_type object) : value_base(std::make_shared<object_type>(std::forward<object_type>(object))) {}
+    value(object_ptr_type object) : value_base(object) {}
 
     explicit operator bool() const { return !is<null_value_t>(); }
 
@@ -80,9 +85,29 @@ struct value : public value_base
     DECLARE_VALUE_TYPE_ACCESOR(Uint, uint64_t)
     DECLARE_VALUE_TYPE_ACCESOR(Bool, bool)
     DECLARE_VALUE_TYPE_ACCESOR(Double, double)
-    DECLARE_VALUE_TYPE_ACCESOR(Array, array_type)
-    DECLARE_VALUE_TYPE_ACCESOR(Object, object_type)
     DECLARE_VALUE_TYPE_ACCESOR(String, std::string)
+    
+    array_ptr_type getArray() noexcept
+    {
+        return match(
+            [](array_ptr_type& val) -> array_ptr_type { return array_ptr_type(val); },
+            [](auto&) -> array_ptr_type { return array_ptr_type(); });
+    }
+    const array_ptr_type getArray() const noexcept
+    {
+        return const_cast<value*>(this)->getArray();
+    }
+
+    object_ptr_type getObject() noexcept
+    {
+        return match(
+            [](object_ptr_type& val) -> object_ptr_type { return object_ptr_type(val); },
+            [](auto&) -> object_ptr_type { return object_ptr_type(); });
+    }
+    const object_ptr_type getObject() const noexcept
+    {
+        return const_cast<value*>(this)->getObject();
+    }
 };
 
 #undef DECLARE_VALUE_TYPE_ACCESOR

--- a/include/mapbox/feature.hpp
+++ b/include/mapbox/feature.hpp
@@ -51,8 +51,6 @@ constexpr bool operator<(const null_value_t&, const null_value_t&) { return fals
 
 constexpr null_value_t null_value = null_value_t();
 
-
-
 #define DECLARE_VALUE_TYPE_ACCESOR(NAME, TYPE)        \
     TYPE* get##NAME() noexcept                        \
     {                                                 \
@@ -125,7 +123,7 @@ struct value : public value_base
     DECLARE_VALUE_TYPE_ACCESOR(Bool, bool)
     DECLARE_VALUE_TYPE_ACCESOR(Double, double)
     DECLARE_VALUE_TYPE_ACCESOR(String, std::string)
-    
+
     array_ptr_type getArray() noexcept
     {
         return match(

--- a/include/mapbox/geometry_io.hpp
+++ b/include/mapbox/geometry_io.hpp
@@ -17,7 +17,7 @@ inline std::ostream& operator<<(std::ostream& os, const empty&)
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const point<T>& point)
 {
-    return os << "[" << point.x << "," << point.y << "]";
+    return os << '[' << point.x << ',' << point.y << ']';
 }
 
 template <typename T, template <class, class...> class C, class... Args>

--- a/include/mapbox/geometry_io.hpp
+++ b/include/mapbox/geometry_io.hpp
@@ -23,7 +23,7 @@ std::ostream& operator<<(std::ostream& os, const point<T>& point)
 template <typename T, template <class, class...> class C, class... Args>
 std::ostream& operator<<(std::ostream& os, const C<T, Args...>& cont)
 {
-    os << "[";
+    os << '[';
     for (auto it = cont.cbegin();;)
     {
         os << *it;
@@ -31,9 +31,9 @@ std::ostream& operator<<(std::ostream& os, const C<T, Args...>& cont)
         {
             break;
         }
-        os << ",";
+        os << ',';
     }
-    return os << "]";
+    return os << ']';
 }
 
 template <typename T>
@@ -100,16 +100,16 @@ void to_stream(std::vector<mapbox::feature::value> const&, std::ostream& dest);
 
 void quote_string(std::string const& in, std::ostream& dest)
 {
-    dest << "\"";
+    dest << '\"';
     for (char c : in)
     {
         if (c == '"' || c == '\\')
         {
-            dest << "\\";
+            dest << '\\';
         }
         dest << c;
     }
-    dest << "\"";
+    dest << '\"';
 }
 
 struct value_to_stream_visitor
@@ -146,7 +146,7 @@ struct value_to_stream_visitor
 
     void operator()(std::vector<mapbox::feature::value> const& vec)
     {
-        out << "[";
+        out << '[';
         bool first = true;
         bool set_in = false;
         if (!in)
@@ -162,7 +162,7 @@ struct value_to_stream_visitor
             }
             else
             {
-                out << ",";
+                out << ',';
             }
             mapbox::util::apply_visitor(*this, item);
         }
@@ -170,7 +170,7 @@ struct value_to_stream_visitor
         {
             in = false;
         }
-        out << "]";
+        out << ']';
     }
 
     void operator()(std::shared_ptr<std::vector<mapbox::feature::value>> const& vec)
@@ -180,7 +180,7 @@ struct value_to_stream_visitor
 
     void operator()(std::unordered_map<std::string, mapbox::feature::value> const& map)
     {
-        out << "{";
+        out << '{';
         std::vector<std::string> keys;
         bool set_in = false;
         if (!in)
@@ -202,18 +202,18 @@ struct value_to_stream_visitor
             }
             else
             {
-                out << ",";
+                out << ',';
             }
             auto const val = map.find(k);
             quote_string(k, out);
-            out << ":";
+            out << ':';
             mapbox::util::apply_visitor(*this, val->second);
         }
         if (set_in)
         {
             in = false;
         }
-        out << "}";
+        out << '}';
     }
 
     void operator()(std::shared_ptr<std::unordered_map<std::string, mapbox::feature::value>> const& map)

--- a/include/mapbox/geometry_io.hpp
+++ b/include/mapbox/geometry_io.hpp
@@ -112,7 +112,10 @@ void quote_string(std::string const& in, std::ostream & dest) {
 struct value_to_stream_visitor {
     
     std::ostream & out;
-    bool in = false;
+    bool in;
+
+    value_to_stream_visitor(std::ostream & out_)
+        : out(out_), in(false) {}
 
     template <typename T>
     void operator()(T val) {
@@ -193,19 +196,19 @@ struct value_to_stream_visitor {
 };
 
 inline std::ostream& operator<<(std::ostream& os, std::unordered_map<std::string, mapbox::feature::value> const& map) {
-    value_to_stream_visitor vis{os};
+    value_to_stream_visitor vis(os);
     vis(map);
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, std::vector<mapbox::feature::value> const& vec) {
-    value_to_stream_visitor vis{os};
+    value_to_stream_visitor vis(os);
     vis(vec);
     return os;
 }
 
 inline std::ostream& operator<<(std::ostream& os, mapbox::feature::value const& val) {
-    mapbox::util::apply_visitor(value_to_stream_visitor{os}, val);
+    mapbox::util::apply_visitor(value_to_stream_visitor(os), val);
     return os;
 }
 

--- a/include/mapbox/geometry_io.hpp
+++ b/include/mapbox/geometry_io.hpp
@@ -94,14 +94,17 @@ inline std::ostream& operator<<(std::ostream& os, const null_value_t&)
     return os << "null";
 }
 
-void to_stream(mapbox::feature::property_map const&, std::ostream & dest);
+void to_stream(mapbox::feature::property_map const&, std::ostream& dest);
 
-void to_stream(std::vector<mapbox::feature::value> const&, std::ostream & dest);
+void to_stream(std::vector<mapbox::feature::value> const&, std::ostream& dest);
 
-void quote_string(std::string const& in, std::ostream & dest) {
+void quote_string(std::string const& in, std::ostream& dest)
+{
     dest << "\"";
-    for (char c : in) {
-        if (c == '"' || c == '\\') {
+    for (char c : in)
+    {
+        if (c == '"' || c == '\\')
+        {
             dest << "\\";
         }
         dest << c;
@@ -109,105 +112,132 @@ void quote_string(std::string const& in, std::ostream & dest) {
     dest << "\"";
 }
 
-struct value_to_stream_visitor {
-    
-    std::ostream & out;
+struct value_to_stream_visitor
+{
+
+    std::ostream& out;
     bool in;
 
-    value_to_stream_visitor(std::ostream & out_)
+    value_to_stream_visitor(std::ostream& out_)
         : out(out_), in(false) {}
 
     template <typename T>
-    void operator()(T val) {
+    void operator()(T val)
+    {
         out << val;
     }
-    
-    void operator()(std::string const& val) {
-        if (in) {
+
+    void operator()(std::string const& val)
+    {
+        if (in)
+        {
             quote_string(val, out);
-        } else {
+        }
+        else
+        {
             out << val;
         }
     }
 
-    void operator()(bool val) {
+    void operator()(bool val)
+    {
         out << (val ? "true" : "false");
     }
 
-    void operator()(std::vector<mapbox::feature::value> const& vec) {
+    void operator()(std::vector<mapbox::feature::value> const& vec)
+    {
         out << "[";
         bool first = true;
         bool set_in = false;
-        if (!in) {
+        if (!in)
+        {
             in = true;
             set_in = true;
         }
-        for (auto const& item : vec) {
-            if (first) {
+        for (auto const& item : vec)
+        {
+            if (first)
+            {
                 first = false;
-            } else {
+            }
+            else
+            {
                 out << ",";
             }
             mapbox::util::apply_visitor(*this, item);
         }
-        if (set_in) {
+        if (set_in)
+        {
             in = false;
         }
         out << "]";
     }
 
-    void operator()(std::shared_ptr<std::vector<mapbox::feature::value>> const& vec) {
+    void operator()(std::shared_ptr<std::vector<mapbox::feature::value>> const& vec)
+    {
         (*this)(*vec);
     }
 
-    void operator()(std::unordered_map<std::string, mapbox::feature::value> const& map) {
+    void operator()(std::unordered_map<std::string, mapbox::feature::value> const& map)
+    {
         out << "{";
         std::vector<std::string> keys;
         bool set_in = false;
-        if (!in) {
+        if (!in)
+        {
             in = true;
             set_in = true;
         }
-        for (auto const& p : map) {
+        for (auto const& p : map)
+        {
             keys.push_back(p.first);
         }
         std::sort(keys.begin(), keys.end());
         bool first = true;
-        for (auto const& k : keys) {
-            if (first) {
+        for (auto const& k : keys)
+        {
+            if (first)
+            {
                 first = false;
-            } else {
-               out << ",";
+            }
+            else
+            {
+                out << ",";
             }
             auto const val = map.find(k);
             quote_string(k, out);
             out << ":";
             mapbox::util::apply_visitor(*this, val->second);
         }
-        if (set_in) {
+        if (set_in)
+        {
             in = false;
         }
         out << "}";
     }
 
-    void operator()(std::shared_ptr<std::unordered_map<std::string, mapbox::feature::value>> const& map) {
+    void operator()(std::shared_ptr<std::unordered_map<std::string, mapbox::feature::value>> const& map)
+    {
         (*this)(*map);
     }
 };
 
-inline std::ostream& operator<<(std::ostream& os, std::unordered_map<std::string, mapbox::feature::value> const& map) {
+inline std::ostream& operator<<(std::ostream& os, std::unordered_map<std::string, mapbox::feature::value> const& map)
+{
     value_to_stream_visitor vis(os);
     vis(map);
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, std::vector<mapbox::feature::value> const& vec) {
+inline std::ostream& operator<<(std::ostream& os, std::vector<mapbox::feature::value> const& vec)
+{
     value_to_stream_visitor vis(os);
     vis(vec);
     return os;
 }
 
-inline std::ostream& operator<<(std::ostream& os, mapbox::feature::value const& val) {
+inline std::ostream& operator<<(std::ostream& os, mapbox::feature::value const& val)
+{
     mapbox::util::apply_visitor(value_to_stream_visitor(os), val);
     return os;
 }

--- a/test/feature.cpp
+++ b/test/feature.cpp
@@ -12,12 +12,38 @@ using mapbox::feature::value;
 namespace {
 
 template <typename T, typename U>
-void checkType(U&& arg) try
+void checkType(U arg) try
 {
-    value v{std::forward<U>(arg)};
+    value v{arg};
     CHECK(v);
     CHECK(v.template is<T>());
     CHECK(v.template get<T>() == arg);
+}
+catch (...)
+{
+    FAIL();
+}
+
+template <typename T, typename U>
+void checkPtrType(U arg) try
+{
+    value v{arg};
+    CHECK(v);
+    CHECK(v.template is<T>());
+    CHECK(*(v.template get<T>()) == *arg);
+}
+catch (...)
+{
+    FAIL();
+}
+
+template <typename T, typename U>
+void checkPtrType2(U arg) try
+{
+    value v{arg};
+    CHECK(v);
+    CHECK(v.template is<T>());
+    CHECK(*(v.template get<T>()) == arg);
 }
 catch (...)
 {
@@ -33,6 +59,15 @@ TEST_CASE("test value")
     checkType<uint64_t>(32u);
     checkType<bool>(false);
     checkType<std::string>("hello");
+
+    value::array_type vec;
+    vec.push_back(value(32));
+    checkPtrType<value::array_ptr_type>(std::make_shared<value::array_type>(vec));
+    checkPtrType2<value::array_ptr_type>(vec);
+    value::object_type map;
+    map.emplace("a", value(33));
+    checkPtrType<value::object_ptr_type>(std::make_shared<value::object_type>(map));
+    checkPtrType2<value::object_ptr_type>(map);
 
     value intV{32};
     CHECK_THROWS(intV.get<uint64_t>());

--- a/test/feature.cpp
+++ b/test/feature.cpp
@@ -61,7 +61,7 @@ TEST_CASE("test value")
     checkType<std::string>("hello");
 
     value::array_type vec;
-    vec.push_back(value(32));
+    vec.emplace_back(value(32));
     checkPtrType<value::array_ptr_type>(std::make_shared<value::array_type>(vec));
     checkPtrType2<value::array_ptr_type>(vec);
     value::object_type map;

--- a/test/io.cpp
+++ b/test/io.cpp
@@ -59,19 +59,19 @@ TEST_CASE("operator<<")
 TEST_CASE("operator<< feature")
 {
     mapbox::feature::null_value_t null;
-    mapbox::feature::value val_null {};
-    mapbox::feature::value val_int {1};
-    mapbox::feature::value val_uint {1U};
-    mapbox::feature::value val_double {1.2};
-    mapbox::feature::value val_str {"foo"};
-    mapbox::feature::value val_str_quote {"\"foo\""};
-    mapbox::feature::value val_str_backslash {"\\"};
-    mapbox::feature::value val_bool_true {true};
-    mapbox::feature::value val_bool_false {false};
+    mapbox::feature::value val_null{};
+    mapbox::feature::value val_int{1};
+    mapbox::feature::value val_uint{1U};
+    mapbox::feature::value val_double{1.2};
+    mapbox::feature::value val_str{"foo"};
+    mapbox::feature::value val_str_quote{"\"foo\""};
+    mapbox::feature::value val_str_backslash{"\\"};
+    mapbox::feature::value val_bool_true{true};
+    mapbox::feature::value val_bool_false{false};
     std::vector<mapbox::feature::value> vec = {1, "fee", true, "\"faa\"", "\\"};
-    mapbox::feature::value val_vec {vec};
+    mapbox::feature::value val_vec{vec};
     std::unordered_map<std::string, mapbox::feature::value> map = {{"fee", "foo"}, {"blah\"", 12}};
-    mapbox::feature::value val_map {map};
+    mapbox::feature::value val_map{map};
 
     std::stringstream stream;
     stream << null << std::endl;
@@ -93,7 +93,7 @@ TEST_CASE("operator<< feature")
 
     std::getline(stream, line);
     CHECK(line == std::string("null"));
-    
+
     std::getline(stream, line);
     CHECK(line == std::string("null"));
 
@@ -117,19 +117,19 @@ TEST_CASE("operator<< feature")
 
     std::getline(stream, line);
     CHECK(line == std::string("true"));
-    
+
     std::getline(stream, line);
     CHECK(line == std::string("false"));
-    
+
     std::getline(stream, line);
     CHECK(line == std::string("[1,\"fee\",true,\"\\\"faa\\\"\",\"\\\\\"]"));
-    
+
     std::getline(stream, line);
     CHECK(line == std::string("[1,\"fee\",true,\"\\\"faa\\\"\",\"\\\\\"]"));
-    
+
     std::getline(stream, line);
     CHECK(line == std::string("{\"blah\\\"\":12,\"fee\":\"foo\"}"));
-    
+
     std::getline(stream, line);
     CHECK(line == std::string("{\"blah\\\"\":12,\"fee\":\"foo\"}"));
 }

--- a/test/io.cpp
+++ b/test/io.cpp
@@ -5,8 +5,6 @@
 
 TEST_CASE("operator<<")
 {
-    mapbox::feature::null_value_t null;
-
     mapbox::geometry::empty empty;
     mapbox::geometry::point<double> point{10, 20};
     mapbox::geometry::point<double> point2{30, 40};
@@ -18,7 +16,6 @@ TEST_CASE("operator<<")
     mapbox::geometry::geometry_collection<double> collection{multiPolygon};
 
     std::stringstream stream;
-    stream << null << std::endl;
     stream << empty << std::endl;
     stream << point << std::endl;
     stream << lineString << std::endl;
@@ -30,9 +27,6 @@ TEST_CASE("operator<<")
     stream << mapbox::geometry::geometry<double>{collection} << std::endl;
 
     std::string line;
-
-    std::getline(stream, line);
-    CHECK(line == std::string("[]"));
 
     std::getline(stream, line);
     CHECK(line == std::string("[]"));
@@ -60,4 +54,82 @@ TEST_CASE("operator<<")
 
     std::getline(stream, line);
     CHECK(line == std::string("[[[[[10,20],[30,40]]]]]"));
+}
+
+TEST_CASE("operator<< feature")
+{
+    mapbox::feature::null_value_t null;
+    mapbox::feature::value val_null {};
+    mapbox::feature::value val_int {1};
+    mapbox::feature::value val_uint {1U};
+    mapbox::feature::value val_double {1.2};
+    mapbox::feature::value val_str {"foo"};
+    mapbox::feature::value val_str_quote {"\"foo\""};
+    mapbox::feature::value val_str_backslash {"\\"};
+    mapbox::feature::value val_bool_true {true};
+    mapbox::feature::value val_bool_false {false};
+    std::vector<mapbox::feature::value> vec = {1, "fee", true, "\"faa\"", "\\"};
+    mapbox::feature::value val_vec {vec};
+    std::unordered_map<std::string, mapbox::feature::value> map = {{"fee", "foo"}, {"blah\"", 12}};
+    mapbox::feature::value val_map {map};
+
+    std::stringstream stream;
+    stream << null << std::endl;
+    stream << val_null << std::endl;
+    stream << val_int << std::endl;
+    stream << val_uint << std::endl;
+    stream << val_double << std::endl;
+    stream << val_str << std::endl;
+    stream << val_str_quote << std::endl;
+    stream << val_str_backslash << std::endl;
+    stream << val_bool_true << std::endl;
+    stream << val_bool_false << std::endl;
+    stream << vec << std::endl;
+    stream << val_vec << std::endl;
+    stream << map << std::endl;
+    stream << val_map << std::endl;
+
+    std::string line;
+
+    std::getline(stream, line);
+    CHECK(line == std::string("null"));
+    
+    std::getline(stream, line);
+    CHECK(line == std::string("null"));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("1"));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("1"));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("1.2"));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("foo"));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("\"foo\""));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("\\"));
+
+    std::getline(stream, line);
+    CHECK(line == std::string("true"));
+    
+    std::getline(stream, line);
+    CHECK(line == std::string("false"));
+    
+    std::getline(stream, line);
+    CHECK(line == std::string("[1,\"fee\",true,\"\\\"faa\\\"\",\"\\\\\"]"));
+    
+    std::getline(stream, line);
+    CHECK(line == std::string("[1,\"fee\",true,\"\\\"faa\\\"\",\"\\\\\"]"));
+    
+    std::getline(stream, line);
+    CHECK(line == std::string("{\"blah\\\"\":12,\"fee\":\"foo\"}"));
+    
+    std::getline(stream, line);
+    CHECK(line == std::string("{\"blah\\\"\":12,\"fee\":\"foo\"}"));
 }


### PR DESCRIPTION
Make feature values nested types be shared ptrs rather than directly stored values. This is often nice because the lifetime of a nested attribute in some situations could be longer than then parent value's lifetime. 